### PR TITLE
add .copy() to make new DataFrames without stupid warnings

### DIFF
--- a/qPCR_analysis.ipynb
+++ b/qPCR_analysis.ipynb
@@ -15,7 +15,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -220,7 +220,7 @@
        "[5 rows x 33 columns]"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -232,7 +232,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -424,7 +424,7 @@
        "68       primer only       NTC  30.4552"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -444,7 +444,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -636,7 +636,7 @@
        "21       Lib+Capseqr       NTC      NaN"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -649,15 +649,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "starting index number, such as type 0 to get the first line 0\n",
-      "ending index number such as type 16 to get the 16th line, indexed as 15 16\n"
+      "starting index number, such as type 0 to get the first line. 0\n",
+      "ending index number such as type 16 to get the 16th line, indexed as 15. 16\n"
      ]
     }
    ],
@@ -669,7 +669,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -819,7 +819,7 @@
        "51   R1_j   UNKNOWN  20.6286"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -833,7 +833,136 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Sample</th>\n",
+       "      <th>Task</th>\n",
+       "      <th>CT</th>\n",
+       "      <th>conc</th>\n",
+       "      <th>log10_conc</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>55</th>\n",
+       "      <td>100pM</td>\n",
+       "      <td>STANDARD</td>\n",
+       "      <td>6.782110</td>\n",
+       "      <td>100.0</td>\n",
+       "      <td>2.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>47</th>\n",
+       "      <td>100pM</td>\n",
+       "      <td>STANDARD</td>\n",
+       "      <td>7.009716</td>\n",
+       "      <td>100.0</td>\n",
+       "      <td>2.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>56</th>\n",
+       "      <td>10pM</td>\n",
+       "      <td>STANDARD</td>\n",
+       "      <td>9.049503</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>48</th>\n",
+       "      <td>10pM</td>\n",
+       "      <td>STANDARD</td>\n",
+       "      <td>9.439298</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>49</th>\n",
+       "      <td>1pM</td>\n",
+       "      <td>STANDARD</td>\n",
+       "      <td>13.617065</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>57</th>\n",
+       "      <td>1pM</td>\n",
+       "      <td>STANDARD</td>\n",
+       "      <td>14.511141</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>50</th>\n",
+       "      <td>0.1pM</td>\n",
+       "      <td>STANDARD</td>\n",
+       "      <td>16.660885</td>\n",
+       "      <td>0.1</td>\n",
+       "      <td>-1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>58</th>\n",
+       "      <td>0.1pM</td>\n",
+       "      <td>STANDARD</td>\n",
+       "      <td>18.032125</td>\n",
+       "      <td>0.1</td>\n",
+       "      <td>-1.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   Sample      Task         CT   conc  log10_conc\n",
+       "55  100pM  STANDARD   6.782110  100.0         2.0\n",
+       "47  100pM  STANDARD   7.009716  100.0         2.0\n",
+       "56   10pM  STANDARD   9.049503   10.0         1.0\n",
+       "48   10pM  STANDARD   9.439298   10.0         1.0\n",
+       "49    1pM  STANDARD  13.617065    1.0         0.0\n",
+       "57    1pM  STANDARD  14.511141    1.0         0.0\n",
+       "50  0.1pM  STANDARD  16.660885    0.1        -1.0\n",
+       "58  0.1pM  STANDARD  18.032125    0.1        -1.0"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#Generate standard curve，need to convert datatype into float for math function\n",
+    "Standards = Result.loc[Result[\"Task\"] == 'STANDARD'].copy()\n",
+    "Standards[\"conc\"] = Standards.Sample.apply(lambda x:  x[0:-2])\n",
+    "Standards.conc = Standards.conc.astype(\"float\")\n",
+    "Standards[\"log10_conc\"] = Standards.conc.apply(lambda x: np.log10(x))\n",
+    "Standards.CT = Standards.CT.astype(\"float\")\n",
+    "Standards"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -969,7 +1098,7 @@
        "58  0.1pM  STANDARD  18.032125    0.1        -1.0"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -986,7 +1115,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -1008,7 +1137,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -1039,27 +1168,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "C:\\Users\\PythonWork\\envs\\HybriSeq\\lib\\site-packages\\pandas\\core\\indexing.py:845: SettingWithCopyWarning: \n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "  self.obj[key] = _infer_fill_value(value)\n",
-      "C:\\Users\\PythonWork\\envs\\HybriSeq\\lib\\site-packages\\pandas\\core\\indexing.py:966: SettingWithCopyWarning: \n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "  self.obj[item] = s\n"
-     ]
-    },
     {
      "data": {
       "text/html": [
@@ -1160,21 +1271,21 @@
        "51   R1_j  UNKNOWN  20.6286  0.012120"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "#Get the probe concentration of UNKNOWN data\n",
-    "unknown = Result.loc[Result[\"Task\"] == 'UNKNOWN']\n",
+    "unknown = Result.loc[Result[\"Task\"] == 'UNKNOWN'].copy()\n",
     "unknown['conc'] = unknown.CT.apply(lambda x: pow(10, (x-b)/k) )\n",
     "unknown"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
Hi @shuqin19, this is a more difficult pull request. **Don't just accept!** If it is too complicated to resolve, just read this message and 'close the pull request'.

I figured our why the warnings were still happening.

When you make a new DataFrame e.g.
Standards = Results.loc[:, ['Some Column', 'Some other column']]

It will just generate a 'view'. The data is not copied, which saves memory, it will just generate a link to the data.

If you use 
Standards = Results.loc[:, ['Some Column', 'Some other column']]**.copy()**

It will copy the data, which will use more memory, but python is less concerned about assigning changes to a copy than to a 'view', so the warnings will stop.